### PR TITLE
circle: Reduce frequency of image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,8 @@ workflows:
     jobs: *jobs
     triggers:
       - schedule:
-          # Run quadridiurnally (4x per day, every 6th hour UTC)
-          cron: "0 0,6,12,18 * * *"
+          # Run daily at 6 PM UTC
+          cron: "0 18 * * *"
           filters:
             branches:
               only: [master]


### PR DESCRIPTION
Since the weekly on the main hybsearch/hybsearch repository runs at 12am UTC, we should run before that, but we probably don't need to keep doing this four times per day.